### PR TITLE
Add a include_data_dir_in_backup boolean

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,3 +1,6 @@
+* Configuration
+     * The 'include_data_dir_in_backup' configuration decides whether the Time Machine backup data should be included in a yunohost backup. Because the size used by Time Machine backups by default is unbounded, the default setting is to ommit the backup data from yunohost backups.
+
 * Known limitations
     * Only the *.local location is detected automatically. To use the domain, you need to first manually connect to the server using the command `open THE_CONNECTION_STRING` on your Mac
     * There is currently no granular control for disallowing connections from hosts (i.e anyone with the username, password and domain can connect to the Time Machine Volume)

--- a/manifest.toml
+++ b/manifest.toml
@@ -41,6 +41,12 @@ ram.runtime = "50M"
     help.fr = "Mot de passe pour accéder à Time Machine"
     type = "password"
 
+    [install.include_data_dir_in_backup]
+    help.en = "Decides if the large Time Machine backup data should be included in a YunoHost backup."
+    help.fr = "Décide si les grandes sauvegardes Time Machine doivent être incluses dans une sauvegarde YunoHost."
+    type = "boolean"
+    default = false
+
 [resources]
     [resources.system_user]
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -19,7 +19,11 @@ ynh_print_info --message="Declaring files to be backed up..."
 # BACKUP THE DATA DIR
 #=================================================
 
-ynh_backup --src_path="$data_dir" --is_big
+if [ "$include_data_dir_in_backup" -eq 1 ]; then
+    ynh_backup --src_path="$data_dir" --is_big
+else
+    echo "Ommitting $data_dir from backup based on include_data_dir_in_backup configuration"
+fi
 
 #=================================================
 # SPECIFIC BACKUP

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -18,6 +18,14 @@ upgrade_type=$(ynh_check_app_version_changed)
 #=================================================
 # SPECIFIC UPGRADE
 #=================================================
+
+# If include_data_dir_in_backup key does not exist, create it
+if [ -z "${include_data_dir_in_backup:-}" ]; then
+    export include_data_dir_in_backup=1
+    ynh_app_setting_set --app="$app" --key=include_data_dir_in_backup --value=$include_data_dir_in_backup
+fi
+
+#=================================================
 # UPDATE A CONFIG FILE
 #=================================================
 ynh_script_progression --message="Updating a configuration file..." --weight=1


### PR DESCRIPTION
This option allows admins to omit Time Machine data in their yunohost backups.

## Problem

- Considering the size of Time Machine backups, make it optional to not include the Time Machine backup data in yunohost backups: #9 

## Solution

- Created a include_data_dir_in_backup boolean which can be toggled to omit the Time Machine data from yunohost backups; while still backing up the app's configuration.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
